### PR TITLE
Fix Android runtime exceptions (issues 8, 9, 10)

### DIFF
--- a/empty-project/Assets/Plugins/Android/QueryAndroidImpl.cs
+++ b/empty-project/Assets/Plugins/Android/QueryAndroidImpl.cs
@@ -65,7 +65,7 @@ internal class QueryAndroidImpl : IQuery {
 			
 			if (valueUpdatedEvent == null) {
 				
-				GetJavaObject().Call<AndroidJavaObject>("removeEventListener", valueupdateListener);
+				GetJavaObject().Call("removeEventListener", valueupdateListener);
 				valueupdateListener = null;
 			}
 			
@@ -87,7 +87,7 @@ internal class QueryAndroidImpl : IQuery {
 			
 			if (childAddedEvent == null && childRemovedEvent == null
 			    && childChangedEvent == null && childMovedEvent == null) {
-				GetJavaObject().Call<AndroidJavaObject>("removeEventListener", childListener);
+				GetJavaObject().Call("removeEventListener", childListener);
 				childListener = null;
 			}
 		}
@@ -108,7 +108,7 @@ internal class QueryAndroidImpl : IQuery {
 			
 			if (childAddedEvent == null && childRemovedEvent == null
 			    && childChangedEvent == null && childMovedEvent == null) {
-				GetJavaObject().Call<AndroidJavaObject>("removeEventListener", childListener);
+				GetJavaObject().Call("removeEventListener", childListener);
 				childListener = null;
 			}
 		}
@@ -129,7 +129,7 @@ internal class QueryAndroidImpl : IQuery {
 			
 			if (childAddedEvent == null && childRemovedEvent == null
 			    && childChangedEvent == null && childMovedEvent == null) {
-				GetJavaObject().Call<AndroidJavaObject>("removeEventListener", childListener);
+				GetJavaObject().Call("removeEventListener", childListener);
 				childListener = null;
 			}
 		}
@@ -150,7 +150,7 @@ internal class QueryAndroidImpl : IQuery {
 			
 			if (childAddedEvent == null && childRemovedEvent == null
 			    && childChangedEvent == null && childMovedEvent == null) {
-				GetJavaObject().Call<AndroidJavaObject>("removeEventListener", childListener);
+				GetJavaObject().Call("removeEventListener", childListener);
 				childListener = null;
 			}
 		}
@@ -252,12 +252,21 @@ internal class QueryAndroidImpl : IQuery {
 			parent.OnChildChanged (new DataSnapshotAndroidImpl (snapshot));
 		}
 
+		void onChildChanged(AndroidJavaObject snapshot, AndroidJavaObject previousChildName) {
+			parent.OnChildChanged (new DataSnapshotAndroidImpl (snapshot));
+		}
+
 		void onChildMoved(AndroidJavaObject snapshot, string previousChildName) {
 			parent.OnChildMoved (new DataSnapshotAndroidImpl (snapshot));
 		}
 
 		void onChildRemoved(AndroidJavaObject snapshot) {
 			parent.OnChildRemoved (new DataSnapshotAndroidImpl (snapshot));
+		}
+
+		bool equals (AndroidJavaObject other)
+		{
+			return other.Equals (this);
 		}
 	}
 }


### PR DESCRIPTION
Fixes three issues:

https://github.com/firebase/Firebase-Unity/issues/8
No such proxy method: QueryAndroidImpl+ChildEventListener.onChildChanged(UnityEngine.AndroidJavaObject,UnityEngine.AndroidJavaObject)

https://github.com/firebase/Firebase-Unity/issues/9
NoSuchMethodError: no non-static method "Lcom/firebase/client/Firebase;.removeEventListener(Lcom.firebase.client.ChildEventListener;)Ljava/lang/Object;"

https://github.com/firebase/Firebase-Unity/issues/10
No such proxy method: QueryAndroidImpl+ChildEventListener.equals(UnityEngine.AndroidJavaObject)
