### PR TITLE
#4 - Support [remove] method for Firebase

### DIFF
--- a/empty-project/Assets/Plugins/Android/FirebaseAndroidImpl.cs
+++ b/empty-project/Assets/Plugins/Android/FirebaseAndroidImpl.cs
@@ -107,8 +107,7 @@ internal class FirebaseAndroidImpl : QueryAndroidImpl, IFirebase
 	}
 	
 	public void Remove () {
-		AndroidJavaObject jsonObject = GetObjectMapper ().Call<AndroidJavaObject> ("readValue", "{}", GetObjectClass ());
-		GetJavaObject().Call ("setValue", jsonObject);
+		SetJsonValue ("{}");
 	}
 
 	public void SetJsonValue (string jsonString) {

--- a/empty-project/Assets/Plugins/Android/FirebaseAndroidImpl.cs
+++ b/empty-project/Assets/Plugins/Android/FirebaseAndroidImpl.cs
@@ -106,6 +106,10 @@ internal class FirebaseAndroidImpl : QueryAndroidImpl, IFirebase
 		GetJavaObject().Call ("setValue", jsonObject);
 	}
 	
+	public void Remove () {
+		AndroidJavaObject jsonObject = GetObjectMapper ().Call<AndroidJavaObject> ("readValue", "{}", GetObjectClass ());
+		GetJavaObject().Call ("setValue", jsonObject);
+	}
 
 	public void SetJsonValue (string jsonString) {
 		AndroidJavaObject jsonObject = GetObjectMapper ().Call<AndroidJavaObject> ("readValue", jsonString, GetObjectClass ());

--- a/empty-project/Assets/Plugins/Editor/FirebaseEditorImpl.cs
+++ b/empty-project/Assets/Plugins/Editor/FirebaseEditorImpl.cs
@@ -148,6 +148,10 @@ public class FirebaseEditorImpl : QueryEditorImpl, IFirebase {
 		_FirebaseSetString (GetEditorObject (), value);
 	}
 
+	public void Remove ()
+	{
+		_FirebaseSetJson (GetEditorObject (), "{}");
+	}
 
 	public void SetJsonValue (string json)
 	{

--- a/empty-project/Assets/Plugins/Editor/FirebaseEditorImpl.cs
+++ b/empty-project/Assets/Plugins/Editor/FirebaseEditorImpl.cs
@@ -150,7 +150,7 @@ public class FirebaseEditorImpl : QueryEditorImpl, IFirebase {
 
 	public void Remove ()
 	{
-		_FirebaseSetJson (GetEditorObject (), "{}");
+		SetJsonValue ("{}");
 	}
 
 	public void SetJsonValue (string json)

--- a/empty-project/Assets/Plugins/Firebase/IFirebase.cs
+++ b/empty-project/Assets/Plugins/Firebase/IFirebase.cs
@@ -28,6 +28,7 @@ public interface IFirebase : IQuery
 
 	IFirebase Push ();
 	void SetValue (string value);
+	void Remove ();
 	void SetJsonValue (string json);
 	void SetValue (float value);
 	void SetValue (IDictionary<string, object> value);

--- a/empty-project/Assets/Plugins/iOS/FirebaseiOSImpl.cs
+++ b/empty-project/Assets/Plugins/iOS/FirebaseiOSImpl.cs
@@ -163,9 +163,13 @@ internal class FirebaseiOSImpl : QueryiOSImpl, IFirebase {
 		_FirebaseSetString (GetiOSObject (), value);
 	}
 
+  public void Remove ()
+	{	
+		SetJsonValue ("{}");
+	}
+
 	public void SetJsonValue (string jsonString)
 	{	
-		Debug.Log (jsonString);
 		_FirebaseSetJson (GetiOSObject (), jsonString);
 	}
 

--- a/empty-project/Assets/Plugins/iOS/FirebaseiOSImpl.cs
+++ b/empty-project/Assets/Plugins/iOS/FirebaseiOSImpl.cs
@@ -163,7 +163,7 @@ internal class FirebaseiOSImpl : QueryiOSImpl, IFirebase {
 		_FirebaseSetString (GetiOSObject (), value);
 	}
 
-  public void Remove ()
+	public void Remove ()
 	{	
 		SetJsonValue ("{}");
 	}

--- a/empty-project/Assets/TestScript.cs
+++ b/empty-project/Assets/TestScript.cs
@@ -37,6 +37,7 @@ public class TestScript : MonoBehaviour {
 		};
 
 		firebase.SetValue ("SetValue working?");
+		firebase.Remove ();
 		firebase.SetJsonValue("{\"example_child\":{\"child_working\" : true}}");
 	}
 	


### PR DESCRIPTION
Adds support for `Remove()` (issue #4), utilizing an empty `SetJsonValue()` request (akin to `SetJsonValue("{}")`
